### PR TITLE
fix getting look-controls enabled and restoring it

### DIFF
--- a/src/ar-camera.js
+++ b/src/ar-camera.js
@@ -4,7 +4,8 @@ AFRAME.registerComponent('ar-camera', {
   },
 
   init: function () {
-    this.wasLookControlsEnabled = this.el.getAttribute('look-controls', 'enabled');
+    var lookControls = this.el.getAttribute('look-controls');
+    this.wasLookControlsEnabled = lookControls ? lookControls.enabled : false;
   },
 
   update: function (oldData) {
@@ -12,12 +13,16 @@ AFRAME.registerComponent('ar-camera', {
       // Value changed, so react accordingly.
       if (this.data.enabled) {
         // Save camera look-controls enabled, and turn off for AR.
-        this.wasLookControlsEnabled = this.el.getAttribute('look-controls', 'enabled');
-        this.el.setAttribute('look-controls', 'enabled', false);
+        var lookControls = this.el.getAttribute('look-controls');
+        this.wasLookControlsEnabled = lookControls ? lookControls.enabled : false;
+        if (this.wasLookControlsEnabled) {
+          this.el.setAttribute('look-controls', 'enabled', false);
+        }
       } else {
         // Restore camera look-controls enabled.
-        this.el.setAttribute('look-controls', 'enabled',
-          this.wasLookControlsEnabled === true);
+        if (this.wasLookControlsEnabled) {
+          this.el.setAttribute('look-controls', 'enabled', true);
+        }
       }
     }
   },


### PR DESCRIPTION
`this.el.getAttribute('look-controls', 'enabled')` completely ignore the second parameter, it's actually the same as `this.el.getAttribute('look-controls')` and return the component.
When restoring, don't create the look-controls component if it wasn't there.

I did a similar fix for aframe-xr https://github.com/mozilla/aframe-xr/pull/18/commits/a24c87450f9d8549ecde646054e72e4ef1e276bf