### PR TITLE
Fix issue with incorrect hit points in hitAR intersections

### DIFF
--- a/src/mozilla-xr-ar.js
+++ b/src/mozilla-xr-ar.js
@@ -781,7 +781,7 @@ NSString *deactivateDetectionImageCallback = [[message body] objectForKey:WEB_AR
 
                 hitsToReturn.push({
                     distance: hitpoint.distanceTo(worldpos),
-                    point: hitpoint, // Vector3
+                    point: hitpoint.clone(), // Vector3
                     object: (el && el.object3D) || this.el.sceneEl.object3D
 /*
                     // We don't have any of these properties...

--- a/src/three-ar.js
+++ b/src/three-ar.js
@@ -151,7 +151,7 @@ AFRAME.registerComponent('three-ar', {
                 raycasterEl.object3D.getWorldPosition(worldpos);
                 hitsToReturn.push({
                     distance: hitpoint.distanceTo(worldpos),
-                    point: hitpoint, // Vector3
+                    point: hitpoint.clone(), // Vector3
                     object: (el && el.object3D) || this.el.sceneEl.object3D
 /*
                     // We don't have any of these properties...


### PR DESCRIPTION
Awesome library!

The `hitAR` methods for both drivers were assigning a closure Vector3 to the hit point in the returned intersection objects. The result was that, on receiving the results, the hit point for every intersection was the same and equal to the position of the last intersection processed. 

It seems this extra allocation is inevitable - it is also done in the three.js mesh racyaster method (https://github.com/mrdoob/three.js/blob/master/src/objects/Mesh.js#L187). 